### PR TITLE
Bugfix: Enforce proper `[start,end,color]` triple

### DIFF
--- a/pxmagic.htm
+++ b/pxmagic.htm
@@ -1861,7 +1861,7 @@
           const repetitions = endIndex - startIndex;
 
           if (repetitions == 1) {
-            pattern.push(currentColor);
+            pattern.push(startIndex, startIndex + 1, currentColor);
           } else {
             pattern.push(startIndex, endIndex, currentColor);
           }
@@ -1873,7 +1873,7 @@
       const lastRepetition = colors.length - startIndex;
 
       if (lastRepetition === 1) {
-        pattern.push(currentColor);
+        pattern.push(startIndex, startIndex + 1, currentColor);
       } else {
         pattern.push(startIndex, colors.length, currentColor);
       }


### PR DESCRIPTION
Problem reported on Discord [#support](https://discord.com/channels/1126966963206361199/1126969359236071465/1403128724072693841) and discussed with 'Smart Home Sellout @ Apollo'

## Problem

Consecutive one-pixel colors no longer collapse into malformed JSON.

## Fix

Always emit proper [start, end, color] triples (using inclusive indices) for both single-pixel and multi-pixel runs. Small code change.

JSON output Was:

```json
1528,"fcfcfc",1528,1548,"000000","2038ec","3cbcfc",1550,1554,"000000","fcfcfc",1555,1580,"000000",
```

With this change:

```json
1528, "fcfcfc", 1528, 1548, "000000", 1548, 1549, "2038ec", 1549, 1550, "3cbcfc", 1550, 1554, "000000", 1554, 1555, "fcfcfc", 1555, 1580, "000000",
```


## Next Steps

Small amount of testing done with images that would and would not fail in current version. Seems ok to merge.


